### PR TITLE
find with req.params not working bug was fixed

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function timeZone(schema, options = {}) {
   }
 
   function subtractOffset(docs, next) {
-    if(!docs || (docs && !docs.length)) return next();
+    if (!docs || (docs && !docs.length)) return next();
     if (docs && !_.isArray(docs)) docs = [docs.constructor.name === 'model' ? docs : this];
     _.each(docs, (result, index) => {
       fixOffset(result, false, () => {

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ module.exports = function timeZone(schema, options = {}) {
   }
 
   function subtractOffset(docs, next) {
+    if(!docs || (docs && !docs.length)) return next();
     if (docs && !_.isArray(docs)) docs = [docs.constructor.name === 'model' ? docs : this];
     _.each(docs, (result, index) => {
       fixOffset(result, false, () => {


### PR DESCRIPTION
docs parameter can be null, empty array or full array. In this case, null and empty array was not controlled. I inserted these conditions.
`if(!docs || (docs && !docs.length)) return next();`